### PR TITLE
Fix acceptance test breakage looking for the word "smaller".

### DIFF
--- a/device.go
+++ b/device.go
@@ -73,7 +73,7 @@ func (d *device) InstallUpdate(image io.ReadCloser, size int64) error {
 		return nil
 	}
 	return errors.New("Can not install image to partition. " +
-		"Size of inactive partition is lower than image size")
+		"Size of inactive partition is smaller than image size")
 }
 
 func (d *device) EnableUpdatedPartition() error {


### PR DESCRIPTION
It *is* grammatically more correct, so opting to change Mender and not
the test.